### PR TITLE
Prepare

### DIFF
--- a/bento/_utils.py
+++ b/bento/_utils.py
@@ -28,6 +28,15 @@ def get_default_args(func):
 def track(func):
     """
     Track changes in AnnData object after applying function.
+    
+    1. First remembers a shallow list of AnnData attributes by listing keys from obs, var, etc.
+    2. Perform arbitrary task
+    3. List attributes again, perform simple diff between list of old and new attributes
+    4. Print to user added and removed keys
+
+    Parameters
+    ----------
+    func : function
     """
 
     @wraps(func)
@@ -85,6 +94,18 @@ def track(func):
 
 
 def list_attributes(adata):
+    """Traverse AnnData object attributes and list keys.
+
+    Parameters
+    ----------
+    adata : AnnData
+        AnnData object
+
+    Returns
+    -------
+    dict
+        Dictionary of keys for each AnnData attribute.
+    """
     found_attr = dict(n_obs=adata.n_obs, n_vars=adata.n_vars)
     for attr in [
         "obs",

--- a/bento/io/__init__.py
+++ b/bento/io/__init__.py
@@ -1,1 +1,1 @@
-from ._io import read_h5ad, write_h5ad, read_geodata, concatenate
+from ._io import read_h5ad, write_h5ad, prepare, concatenate

--- a/bento/plotting/_plotting.py
+++ b/bento/plotting/_plotting.py
@@ -509,7 +509,7 @@ def shape_subplot(data, shape_names, dx, units, ax, ax_radius=None):
     ax.add_artist(scalebar)
 
 
-def sig_samples(data, n=5):
+def sig_samples(data, n=5, col_wrap=2):
     for f in data.uns["tensor_loadings"][TENSOR_DIM_NAMES[0]]:
         top_genes = (
             data.uns["tensor_loadings"]["genes"]
@@ -528,6 +528,7 @@ def sig_samples(data, n=5):
             kind="scatter",
             hue="gene",
             col="cell",
+            col_wrap=col_wrap,
             height=2,
         )
         # plt.suptitle(f)

--- a/bento/plotting/_plotting.py
+++ b/bento/plotting/_plotting.py
@@ -342,11 +342,9 @@ def lp_diff(data, phenotype, fname=None):
 @savefig
 def cellplot(
     adata,
-    fovs="0",
-    fov_key="batch",
     hue=None,
-    col=None,
     kind="hist",
+    col="batch",
     legend=True,
     palette=None,
     hue_order=None,
@@ -354,7 +352,9 @@ def cellplot(
     col_wrap=None,
     col_order=None,
     shape_names=["cell_shape", "nucleus_shape"],
-    height=8,
+    dx=0.1,
+    units="um",
+    height=6,
     facet_kws=None,
     fname=None,
     **kwargs,
@@ -362,43 +362,26 @@ def cellplot(
     # Get points
     points = get_points(adata, asgeo=False)
 
-    # Process fovs
-    if fovs == "all":
-        fovs = adata.obs[fov_key].unique().tolist()
+    # Add all shape_names if None
+    if shape_names == None:
+        shape_names = adata.obs.columns[adata.obs.columns.str.endswith("_shape")]
 
-    fovs = [fovs] if isinstance(fovs, str) else fovs
-
-    # Add all shape_names if 'all'
-    if shape_names == "all":
-        shape_names = adata.obs.columns[adata.obs.columns.str.endswith("shape")]
-
-    # Convert draw_shape_names to list
+    # Convert shape_names to list
     shape_names = [shape_names] if isinstance(shape_names, str) else shape_names
 
-    # Get shapes
-    obs_columns = list(shape_names)
-    if col:
-        # Likely mistake
-        if col == 'fov' or col == 'fovs':
-            col = fov_key
-            
-        obs_columns.append(col)
-    if fov_key:
-        obs_columns.append(fov_key)
-    obs_columns = list(set(obs_columns))
+    # Get obs attributes starting with shapes
+    obs_attrs = list(shape_names)
+
+    # Include col if exists
+    if col and col in adata.obs.columns and col in points.columns:
+        obs_attrs.append(col)
+    else:
+        col = None
+
+    obs_attrs = list(set(obs_attrs))
 
     # Get shapes
-    shapes = adata.obs.reset_index()[obs_columns]
-
-    # Make sure col is same type across points and shapes
-    if points[fov_key].dtype != shapes[fov_key].dtype:
-        points[fov_key] = points[fov_key].astype(str)
-        shapes[fov_key] = shapes[fov_key].astype(str)
-
-    if fovs[0] != "all":
-        # Subset to specified col values only; less filtering = faster plotting
-        points = points[points[fov_key].isin(fovs)]
-        shapes = shapes[shapes[fov_key].isin(fovs)]
+    shapes = adata.obs.reset_index()[obs_attrs]
 
     if col:
         # Make sure col is same type across points and shapes
@@ -412,12 +395,13 @@ def cellplot(
             shapes = shapes[shapes[col].isin(col_order)]
 
     # Remove unused categories in points
-    for cat in points.columns:
-        points[cat] = (
-            points[cat].cat.remove_unused_categories()
-            if points[cat].dtype == "category"
-            else points[cat]
-        )
+    if col or hue:
+        for cat in points.columns:
+            points[cat] = (
+                points[cat].cat.remove_unused_categories()
+                if points[cat].dtype == "category"
+                else points[cat]
+            )
 
     # Convert shapes to GeoDataFrames AFTER filtering
     shapes = geopandas.GeoDataFrame(shapes, geometry="cell_shape")
@@ -443,19 +427,6 @@ def cellplot(
         **kws,
     )
 
-    def hexbin(data, x, y, **kwargs):
-        xmax = data[x].max()
-        xmin = data[x].min()
-        ymax = data[y].max()
-        ymin = data[y].min()
-        dx = xmax - xmin
-        dy = ymax - ymin
-        nx = kwargs['gridsize']
-        ny = int((dy/dx) * nx)
-        print(nx, ny)
-        kwargs['gridsize'] = (nx, ny)
-        plt.hexbin(data[x], data[y], extent=(xmin, xmax, ymin, ymax), **kwargs)
-    
     if kind == "scatter":
         scatter_kws = dict(linewidth=0, s=5)
         scatter_kws.update(**kwargs)
@@ -469,28 +440,29 @@ def cellplot(
         hex_kws.update(**kwargs)
         g.map_dataframe(plt.hexbin, x="x", y="y", **hex_kws)
 
-    if col:
-        shapes = shapes.groupby(col)
+    if shapes.shape[0] > 0:
+        if col:
+            shapes = shapes.groupby(col)
 
-        # Get max ax radius across groups
-        ax_radii = []
-        for k, ax in g.axes_dict.items():
-            s = shapes.get_group(k)
-            # Determine fixed radius of each subplot
-            cell_bounds = s.bounds
-            cell_maxw = cell_bounds["maxx"].max() - cell_bounds["minx"].min()
-            cell_maxh = cell_bounds["maxy"].max() - cell_bounds["miny"].min()
-            ax_radius = 1.1 * (max(cell_maxw, cell_maxh) / 2)
-            ax_radii.append(ax_radius)
+            # Get max ax radius across groups
+            ax_radii = []
+            for k, ax in g.axes_dict.items():
+                s = shapes.get_group(k)
+                # Determine fixed radius of each subplot
+                cell_bounds = s.bounds
+                cell_maxw = cell_bounds["maxx"].max() - cell_bounds["minx"].min()
+                cell_maxh = cell_bounds["maxy"].max() - cell_bounds["miny"].min()
+                ax_radius = 1.1 * (max(cell_maxw, cell_maxh) / 2)
+                ax_radii.append(ax_radius)
 
-        ax_radius = max(ax_radii)
+            ax_radius = max(ax_radii)
 
-        for k, ax in tqdm(g.axes_dict.items()):
-            s = shapes.get_group(k)
-            shape_subplot(s, shape_names, ax_radius=ax_radius, ax=ax)
+            for k, ax in tqdm(g.axes_dict.items()):
+                s = shapes.get_group(k)
+                shape_subplot(s, shape_names, dx, units, ax_radius=ax_radius, ax=ax)
 
-    else:
-        shape_subplot(shapes, shape_names, ax=g.ax)
+        else:
+            shape_subplot(shapes, shape_names, dx, units, ax=g.ax)
 
     if legend:
         g.add_legend()
@@ -512,10 +484,12 @@ def cellplot(
     g.tight_layout()
 
 
-def shape_subplot(data, shape_names, ax, ax_radius=None):
+def shape_subplot(data, shape_names, dx, units, ax, ax_radius=None):
     # Gather all shapes and plot
     all_shapes = geopandas.GeoSeries(data[shape_names].values.flatten())
-    all_shapes.plot(color=(0,0,0,0), edgecolor=(1, 1, 1, 0.8), lw=1, aspect=None, ax=ax)
+    all_shapes.plot(
+        color=(0, 0, 0, 0), edgecolor=(1, 1, 1, 0.8), lw=1, aspect=None, ax=ax
+    )
 
     # Set axes boundaries to be square; make sure size of cells are relative to one another
     if ax_radius:
@@ -530,13 +504,13 @@ def shape_subplot(data, shape_names, ax, ax_radius=None):
 
     # Create scale bar
     scalebar = ScaleBar(
-        0.1, "um", location="lower right", color="white", box_alpha=0, scale_loc="top"
+        dx, units, location="lower right", color="white", box_alpha=0, scale_loc="top"
     )
     ax.add_artist(scalebar)
 
-    
+
 def sig_samples(data, n=5):
-    for f in data.uns['tensor_loadings'][TENSOR_DIM_NAMES[0]]:
+    for f in data.uns["tensor_loadings"][TENSOR_DIM_NAMES[0]]:
         top_genes = (
             data.uns["tensor_loadings"]["genes"]
             .sort_values(f, ascending=False)
@@ -551,7 +525,6 @@ def sig_samples(data, n=5):
 
         cellplot(
             data[top_cells, top_genes],
-            fovs="all",
             kind="scatter",
             hue="gene",
             col="cell",

--- a/bento/plotting/_plotting.py
+++ b/bento/plotting/_plotting.py
@@ -373,7 +373,7 @@ def cellplot(
     obs_attrs = list(shape_names)
 
     # Include col if exists
-    if col and col in adata.obs.columns and col in points.columns:
+    if col and (col == "cell" or (col in adata.obs.columns and col in points.columns)):
         obs_attrs.append(col)
     else:
         col = None

--- a/bento/preprocessing/__init__.py
+++ b/bento/preprocessing/__init__.py
@@ -1,2 +1,1 @@
-from ._preprocessing import (get_layers, get_points,
-                             remove_extracellular, set_points, subsample)
+from ._preprocessing import get_layers, get_points, set_points

--- a/bento/preprocessing/_preprocessing.py
+++ b/bento/preprocessing/_preprocessing.py
@@ -1,8 +1,4 @@
-import dask.dataframe as dd
-import dask_geopandas
 import geopandas as gpd
-from dask.diagnostics import ProgressBar
-from tqdm.auto import tqdm
 
 from .._utils import track
 
@@ -50,7 +46,7 @@ def get_points(data, asgeo=False):
 
 @track
 def set_points(data, copy=False):
-    """Set points for the given `AnnData` object, data. Call this setter 
+    """Set points for the given `AnnData` object, data. Call this setter
     to keep the points DataFrame in sync.
 
     Parameters
@@ -67,92 +63,6 @@ def set_points(data, copy=False):
     adata = data.copy() if copy else data
     points = get_points(adata)
     adata.uns["points"] = points
-    return adata if copy else None
-
-
-@track
-def remove_extracellular(data, copy=False):
-    """
-    Remove extracellular points.
-    """
-    adata = data.copy() if copy else data
-    points = get_points(adata)
-
-    points = points.set_index("cell").join(data.obs["cell_shape"]).reset_index()
-    points["cell"] = points["cell"].astype("category").cat.as_ordered()
-
-    def _filter_points(pts):
-        pts = gpd.GeoDataFrame(pts, geometry=gpd.points_from_xy(pts.x, pts.y))
-
-        cell_shape = pts["cell_shape"].values[0]
-        in_cell = pts.within(cell_shape)
-        pts = pts[in_cell]
-
-        return pts
-
-    ngroups = points.groupby("cell").ngroups
-
-    if ngroups > 100:
-        npartitions = min(1000, ngroups)
-
-        with ProgressBar():
-
-            points = (
-                dask_geopandas.from_geopandas(
-                    points,
-                    npartitions=npartitions,
-                )
-                .groupby("cell", observed=True)
-                .apply(_filter_points, meta=dict(zip(points.columns, points.dtypes)))
-                .compute()
-            )
-    else:
-        tqdm.pandas()
-        points.groupby("cell").progress_apply(_filter_points)
-
-    points = (
-        points.drop("cell_shape", axis=1)
-        .drop("geometry", axis=1)
-        .reset_index(drop=True)
-    )
-
-    cat_vars = ["cell", "gene", "nucleus"]
-    points[cat_vars] = points[cat_vars].astype("category")
-
-    adata.uns["points"] = points
-
-    return adata if copy else None
-
-
-@track
-def subsample(data, frac=0.2, copy=True):
-    """
-    Subsample transcripts, preserving the number of cells and genes detected per cell.
-    """
-    adata = data.copy() if copy else data
-    points = get_points(data)
-
-    with ProgressBar():
-        sampled_pts = (
-            dd.from_pandas(points, chunksize=1000000)
-            .groupby(["cell", "gene"])
-            .apply(
-                lambda df: df.sample(frac=frac),
-                meta=dict(zip(points.columns, points.dtypes)),
-            )
-            .reset_index(drop=True)
-            .compute()
-        )
-
-    X = sampled_pts[["cell", "gene"]].pivot_table(
-        index="cell", columns="gene", aggfunc=len, fill_value=0
-    )
-
-    adata.uns["points"] = sampled_pts
-
-    adata = adata[X.index, X.columns]
-    adata.X = X
-
     return adata if copy else None
 
 
@@ -187,7 +97,10 @@ def get_layers(data, layers, min_count=None):
 
     for layer in layers:
         values = (
-            data.to_df(layer).reset_index().melt(id_vars="cell").set_index(["cell", "gene"])
+            data.to_df(layer)
+            .reset_index()
+            .melt(id_vars="cell")
+            .set_index(["cell", "gene"])
         )
         values.columns = [layer]
         sample_index = sample_index.join(values)

--- a/bento/tools/_cell_features.py
+++ b/bento/tools/_cell_features.py
@@ -496,6 +496,10 @@ cell_features = dict(
     cell_perimeter=cell_perimeter,
     cell_radius=cell_radius,
     cell_morph_open=cell_morph_open,
+    nucleus_area=nucleus_area,
+    nucleus_area_ratio=nucleus_area_ratio,
+    nucleus_aspect_ratio=nucleus_aspect_ratio,
+    nucleus_offset=nucleus_offset,
 )
 """Dict of cell feature names : function. Pass a list of feature name(s) to
 `bento.tl.analyze_cells()` to compute them.

--- a/bento/tools/_cell_features.py
+++ b/bento/tools/_cell_features.py
@@ -9,7 +9,7 @@ from .._utils import track
 
 
 @track
-def analyze_cells(data, feature_names, copy=False):
+def analyze_cells(data, feature_names, progress=True, copy=False):
     """Compute multiple cell features at once. Convenience function instead of making 
     separate calls to compute each feature.
 
@@ -36,8 +36,12 @@ def analyze_cells(data, feature_names, copy=False):
 
     feature_names = list(set(feature_names))
 
-    for f in tqdm(feature_names):
-        cell_features[f].__wrapped__(adata)
+    if progress:
+        for f in tqdm(feature_names):
+            cell_features[f].__wrapped__(adata)
+    else:
+        for f in feature_names:
+            cell_features[f].__wrapped__(adata)
 
     return adata if copy else None
 

--- a/bento/tools/_lp.py
+++ b/bento/tools/_lp.py
@@ -49,7 +49,7 @@ def lp(data, min_count=5, copy=False):
             "point_dispersion",
             "nucleus_dispersion",
         ]
-        bento.tl.analyze_samples(data, features, chunksize=100)
+        bento.tl.analyze_samples(data, features)
 
     X_df = get_layers(adata, PATTERN_MODEL_FEATURE_NAMES, min_count)
 

--- a/bento/tools/_lp.py
+++ b/bento/tools/_lp.py
@@ -61,9 +61,7 @@ def lp(data, min_count=5, copy=False):
     )
     thresholds = [0.45300, 0.43400, 0.37900, 0.43700, 0.50500]
     # Save each pattern to adata
-    for p, pp, thresh in tqdm(
-        zip(PATTERN_NAMES, PATTERN_PROBS, thresholds), total=len(PATTERN_NAMES)
-    ):
+    for p, pp, thresh in zip(PATTERN_NAMES, PATTERN_PROBS, thresholds):
         indicator_df = (
             (pattern_prob >= thresh)
             .reset_index()

--- a/bento/tools/_sample_features.py
+++ b/bento/tools/_sample_features.py
@@ -7,7 +7,7 @@ from scipy.spatial import distance
 import dask_geopandas
 import geopandas as gpd
 import numpy as np
-import modin.pandas as pd
+import pandas as pd
 from dask.diagnostics import ProgressBar
 
 from .. import tools as tl

--- a/bento/tools/_sample_features.py
+++ b/bento/tools/_sample_features.py
@@ -77,6 +77,16 @@ def analyze_samples(data, features, copy=False):
         .reset_index(drop=True)
     )
 
+    # Handle categories as strings to avoid ambiguous cat types
+    for col in points_df.loc[:,(points_df.dtypes == 'category').values]:
+        points_df[col] = points_df[col].astype(str)
+
+    # Handle shape indexes as strings to avoid ambiguous types
+    for shape_name in adata.obs.columns[adata.obs.columns.str.endswith('_shape')]:
+        shape_prefix = '_'.join(shape_name.split('_')[:-1])
+        if shape_prefix in points_df.columns:
+            points_df[shape_prefix] = points_df[shape_prefix].astype(str)
+
     # Calculate features for a sample
     def process_sample(df):
         sample_output = {}
@@ -93,7 +103,7 @@ def analyze_samples(data, features, copy=False):
     # Cast to dask dataframe
     ddf = dask_geopandas.from_geopandas(points_df, npartitions=1)
 
-    # Partition so only 100 groups per groupby
+    # Partition so only 1000 groups per groupby
     _, group_loc = np.unique(
         points_df["cell"].astype(str) + "-" + points_df["gene"].astype(str),
         return_index=True,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,15 @@
 [[package]]
+name = "affine"
+version = "2.3.1"
+description = "Matrices describing affine transformation of the plane."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["pytest (>=4.6)", "pytest-cov", "pydocstyle", "flake8", "coveralls"]
+
+[[package]]
 name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
@@ -1517,6 +1528,32 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
+name = "rasterio"
+version = "1.2.10"
+description = "Fast and direct raster I/O for use with Numpy and SciPy"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+affine = "*"
+attrs = "*"
+certifi = "*"
+click = ">=4.0"
+click-plugins = "*"
+cligj = ">=0.5"
+numpy = "*"
+snuggs = ">=1.4.1"
+
+[package.extras]
+all = ["numpydoc", "hypothesis", "matplotlib", "pytest-cov (>=2.2.0)", "sphinx", "ipython (>=2.0)", "boto3 (>=1.2.4)", "shapely", "pytest (>=2.8.2)", "packaging", "sphinx-rtd-theme", "ghp-import"]
+docs = ["ghp-import", "numpydoc", "sphinx", "sphinx-rtd-theme"]
+ipython = ["ipython (>=2.0)"]
+plot = ["matplotlib"]
+s3 = ["boto3 (>=1.2.4)"]
+test = ["boto3 (>=1.2.4)", "hypothesis", "packaging", "pytest-cov (>=2.2.0)", "pytest (>=2.8.2)", "shapely"]
+
+[[package]]
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
@@ -1689,6 +1726,21 @@ description = "This package provides 29 stemmers for 28 languages generated from
 category = "main"
 optional = true
 python-versions = "*"
+
+[[package]]
+name = "snuggs"
+version = "1.4.7"
+description = "Snuggs are s-expressions for Numpy"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+pyparsing = ">=2.1.6"
+
+[package.extras]
+test = ["pytest", "hypothesis"]
 
 [[package]]
 name = "sortedcontainers"
@@ -2183,9 +2235,13 @@ torch = ["torch"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "799557fdcdff75b52ec633c2cfea98cd97df29174a4fb47e125ee2eb23e6d5ba"
+content-hash = "eb6a3ff4f43b481a5f0a607931c2a2eebaae47f30bfe214aeb826faca7dfd85e"
 
 [metadata.files]
+affine = [
+    {file = "affine-2.3.1-py2.py3-none-any.whl", hash = "sha256:de17839ff05e965580870c3b15e14cefd7992fa05dba9202a0879bbed0c171e4"},
+    {file = "affine-2.3.1.tar.gz", hash = "sha256:d676de66157ad6af99ffd94e0f54e89dfc35b0fb7252ead2ed0ad2dca431bdd0"},
+]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
@@ -3343,6 +3399,17 @@ pyzmq = [
     {file = "pyzmq-23.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:05ec90a8da618f2398f9d1aa20b18a9ef332992c6ac23e8c866099faad6ef0d6"},
     {file = "pyzmq-23.1.0.tar.gz", hash = "sha256:1df26aa854bdd3a8341bf199064dd6aa6e240f2eaa3c9fa8d217e5d8b868c73e"},
 ]
+rasterio = [
+    {file = "rasterio-1.2.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f86efb0e4989201f244d6818575d442b716ce81af6cd969c3caead76b9690837"},
+    {file = "rasterio-1.2.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:831b6dbefb409c3ece23fa219d8446a7534e30c69a075fd366e72742b1f94c58"},
+    {file = "rasterio-1.2.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:42a1a6364313c384fcd631d850792621301e930449b47f72ced048c415c9c84e"},
+    {file = "rasterio-1.2.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1572003273225162933d4c88729076ac39050e7becd9de7d31988d1dd40942c1"},
+    {file = "rasterio-1.2.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f9867a3b6663396260fc5bdfbea372cac9202074b709478db741767f40dfffc"},
+    {file = "rasterio-1.2.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ba95aa3221814e364ef49cf8dd8ca4a73e2ea702bd9228a3a845e197091792ae"},
+    {file = "rasterio-1.2.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2394ce0ae1e7b49b456ddc6bbf00ce6840656e926046c1a5a54cd0f66ea67dc4"},
+    {file = "rasterio-1.2.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c73248b4ba0564798bf64df869834821a7b823a4c9ceda3de9b772d69c3f5405"},
+    {file = "rasterio-1.2.10.tar.gz", hash = "sha256:6062456047ba6494fe18bd0da98a383b6fad5306b16cd52a22e76c59172a2b5f"},
+]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
@@ -3454,6 +3521,10 @@ six = [
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+snuggs = [
+    {file = "snuggs-1.4.7-py3-none-any.whl", hash = "sha256:988dde5d4db88e9d71c99457404773dabcc7a1c45971bfbe81900999942d9f07"},
+    {file = "snuggs-1.4.7.tar.gz", hash = "sha256:501cf113fe3892e14e2fee76da5cd0606b7e149c411c271898e6259ebde2617b"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,7 +3,7 @@ name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -117,7 +117,7 @@ name = "babel"
 version = "2.10.1"
 description = "Internationalization utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -211,7 +211,7 @@ name = "charset-normalizer"
 version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5.0"
 
 [package.extras]
@@ -373,8 +373,19 @@ name = "docutils"
 version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "emoji"
+version = "1.7.0"
+description = "Emoji for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+dev = ["pytest", "coverage", "coveralls"]
 
 [[package]]
 name = "entrypoints"
@@ -525,7 +536,7 @@ name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -549,7 +560,7 @@ name = "imagesize"
 version = "1.3.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -557,7 +568,7 @@ name = "importlib-metadata"
 version = "4.11.4"
 description = "Read metadata from Python packages"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -840,7 +851,7 @@ name = "markdown-it-py"
 version = "2.1.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -910,7 +921,7 @@ name = "mdit-py-plugins"
 version = "0.3.0"
 description = "Collection of plugins for markdown-it-py"
 category = "main"
-optional = false
+optional = true
 python-versions = "~=3.6"
 
 [package.dependencies]
@@ -926,7 +937,7 @@ name = "mdurl"
 version = "0.1.1"
 description = "Markdown URL utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [[package]]
@@ -965,7 +976,7 @@ name = "myst-parser"
 version = "0.18.0"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1510,7 +1521,7 @@ name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
@@ -1676,7 +1687,7 @@ name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -1700,7 +1711,7 @@ name = "sphinx"
 version = "4.5.0"
 description = "Python documentation generator"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -1766,7 +1777,7 @@ name = "sphinx-gallery"
 version = "0.10.1"
 description = "A Sphinx extension that builds an HTML version of any Python script and puts it into an examples gallery."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1777,7 +1788,7 @@ name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1789,7 +1800,7 @@ name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1801,7 +1812,7 @@ name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -1813,7 +1824,7 @@ name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1824,7 +1835,7 @@ name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -1836,7 +1847,7 @@ name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.extras]
@@ -2040,7 +2051,7 @@ name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [[package]]
@@ -2166,13 +2177,13 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-docs = ["Sphinx", "sphinx-autobuild", "sphinx-book-theme", "nbsphinx"]
+docs = ["Sphinx", "sphinx-autobuild", "sphinx-book-theme", "nbsphinx", "sphinx-gallery", "myst-parser"]
 torch = ["torch"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "8f44c668c2a9a32c7fdee676553a1c91886044576a8b20272062605cc1c77a6e"
+content-hash = "799557fdcdff75b52ec633c2cfea98cd97df29174a4fb47e125ee2eb23e6d5ba"
 
 [metadata.files]
 alabaster = [
@@ -2386,6 +2397,9 @@ distributed = [
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
     {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
+]
+emoji = [
+    {file = "emoji-1.7.0.tar.gz", hash = "sha256:65c54533ea3c78f30d0729288998715f418d7467de89ec258a31c0ce8660a1d1"},
 ]
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ scanpy = "^1.8.1"
 UpSetPlot = "^0.6.0"
 cell2cell = "^0.5.10"
 xgboost = ">=1.4.0,<1.5"
-
 torch = { version = "^1.9.0", optional = true }
 
 Sphinx = { version = "^4.1.2", optional = true }
@@ -40,10 +39,14 @@ sphinx-book-theme = { version = "^0.3.2", optional = true }
 nbsphinx = {version = "^0.8.9", optional = true }
 sphinx-gallery = { version = "^0.10.1", optional = true }
 myst-parser = { version = "^0.18.0", optional = true }
+emoji = "^1.7.0"
 
 [tool.poetry.extras]
 torch = ["torch"]
 docs = ["Sphinx", "sphinx-autobuild", "sphinx-book-theme", "nbsphinx", "sphinx-gallery", "myst-parser"]
+
+[tool.setuptools]
+py_modules=[]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", 'setuptools']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ nbsphinx = {version = "^0.8.9", optional = true }
 sphinx-gallery = { version = "^0.10.1", optional = true }
 myst-parser = { version = "^0.18.0", optional = true }
 emoji = "^1.7.0"
+rasterio = "^1.2.10"
 
 [tool.poetry.extras]
 torch = ["torch"]

--- a/tests/test_sample_features.py
+++ b/tests/test_sample_features.py
@@ -7,44 +7,4 @@ data = bento.datasets.sample_data()
 class TestSampleFeatures(unittest.TestCase):
     def test_analyze(self):
         features = list(bento.tl.sample_features.keys())
-        bento.tl.analyze_samples(data, features, chunksize=100)
-
-    # def test_proximity_cell(self):
-    #     bento.tl.analyze(data, bento.tl.ShapeProximity("cell_shape"), chunks=1)
-    #     self.assertTrue("cell_inner_proximity" in data.layers)
-    #     self.assertTrue("cell_outer_proximity" in data.layers)
-
-    # def test_proximity_nucleus(self):
-    #     bento.tl.analyze(data, bento.tl.ShapeProximity("nucleus_shape"), chunks=1)
-    #     self.assertTrue("nucleus_inner_proximity" in data.layers)
-    #     self.assertTrue("nucleus_outer_proximity" in data.layers)
-
-    # def test_asymmetry_cell(self):
-    #     bento.tl.analyze(data, bento.tl.ShapeAsymmetry("cell_shape"), chunks=1)
-    #     self.assertTrue("cell_inner_asymmetry" in data.layers)
-    #     self.assertTrue("cell_outer_asymmetry" in data.layers)
-
-    # def test_asymmetry_nucleus(self):
-    #     bento.tl.analyze(data, bento.tl.ShapeAsymmetry("nucleus_shape"), chunks=1)
-    #     self.assertTrue("nucleus_inner_asymmetry" in data.layers)
-    #     self.assertTrue("nucleus_outer_asymmetry" in data.layers)
-
-    # def test_ripley_stats(self):
-    #     bento.tl.analyze(data, bento.tl.RipleyStats(), chunks=1)
-    #     self.assertTrue("l_max" in data.layers)
-    #     self.assertTrue("l_max_gradient" in data.layers)
-    #     self.assertTrue("l_min_gradient" in data.layers)
-    #     self.assertTrue("l_monotony" in data.layers)
-    #     self.assertTrue("l_half_radius" in data.layers)
-
-    # def test_point_dispersion(self):
-    #     bento.tl.analyze(data, bento.tl.PointDispersion(), chunks=1)
-    #     self.assertTrue("point_dispersion" in data.layers)
-
-    # def test_shape_dispersion(self):
-    #     bento.tl.analyze(data, bento.tl.ShapeDispersion("nucleus_shape"), chunks=1)
-    #     self.assertTrue("nucleus_dispersion" in data.layers)
-
-    # def test_shape_enrichment(self):
-    #     bento.tl.analyze(data, bento.tl.ShapeEnrichment("nucleus_shape"), chunks=1)
-    #     self.assertTrue("nucleus_enrichment" in data.layers)
+        bento.tl.analyze_samples(data, features)


### PR DESCRIPTION
### Improvements to IO and feature computations
- `bento.io.prepare()`: first stab at ingesting external molecular and segmentation data 1fb026b
  - first assigns secondary seg. masks to cell in a 1-to-1 fashion
  - indexes points to cells and mapped sec. shapes
- `bento.tl.analyze_samples`: sample computation memory usage is now tractable
  - naive dask partitioning only accounted for memory footprint of `points` dataframe, but memory blowup comes from MultiIndex `groupby` operations 
  - custom partitioning ensures partitions have capped number of groupby groups
  - in the future make it a user parameter? needs more testing
- some progress bars and emojis :cake: